### PR TITLE
add a way to give x any y offsets (pixels)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,20 @@ impl CornerAlignment {
       },
     }
   }
+
+  pub fn padding(&self, offset_x: i32, offset_y: i32) -> String {
+    let (top, bottom) = match self.y {
+      Alignment::Start => (offset_y, 0),
+      Alignment::End => (0, offset_y),
+      Alignment::Center => (0, 0),
+    };
+    let (left, right) = match self.x {
+      Alignment::Start => (offset_x, 0),
+      Alignment::End => (0, offset_x),
+      Alignment::Center => (0, 0),
+    };
+    format!("{top} {right} {bottom} {left}")
+  }
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -75,6 +89,14 @@ pub struct Config {
   pub user_id: String,
   pub message_alignment: String,
   pub user_alignment: String,
+  #[serde(default)]
+  pub message_offset_x: i32,
+  #[serde(default)]
+  pub message_offset_y: i32,
+  #[serde(default)]
+  pub user_offset_x: i32,
+  #[serde(default)]
+  pub user_offset_y: i32,
   pub voice_semitransparent: bool,
   pub messages_semitransparent: bool,
   pub is_keybind_enabled: bool,
@@ -87,6 +109,10 @@ impl Default for Config {
       user_id: String::new(),
       message_alignment: "topright".into(),
       user_alignment: "topleft".into(),
+      message_offset_x: 0,
+      message_offset_y: 0,
+      user_offset_x: 0,
+      user_offset_y: 0,
       voice_semitransparent: true,
       messages_semitransparent: false,
       is_keybind_enabled: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,6 +234,9 @@ fn app() -> Element {
       height: "100%",
       width: "100%",
 
+      padding: CornerAlignment::from_str(&app_state.read().config.user_alignment)
+        .padding(app_state.read().config.user_offset_x, app_state.read().config.user_offset_y),
+
       for user in app_state.read().voice_users.iter() {
         user_row {
           user: {
@@ -263,6 +266,9 @@ fn app() -> Element {
       background: "transparent",
       height: "100%",
       width: "100%",
+
+      padding: CornerAlignment::from_str(&app_state.read().config.message_alignment)
+        .padding(app_state.read().config.message_offset_x, app_state.read().config.message_offset_y),
 
       opacity: if app_state.read().config.messages_semitransparent && !app_state.read().is_open { "0.5" } else { "1.0" },
 


### PR DESCRIPTION
if this gets merged ill pr an update for the equicord plugin aswell

makes it so i can fix things like this 

<img width="509" height="164" alt="image" src="https://github.com/user-attachments/assets/0a48f90f-3d80-4760-9bd3-5e99bae5ee94" />
<img width="510" height="164" alt="image" src="https://github.com/user-attachments/assets/71ecbc64-7c67-4b15-9bab-ececbba4d20a" />
