### PR TITLE
fix a couple panics and perf issues

### DIFF
--- a/src/components/message_row.rs
+++ b/src/components/message_row.rs
@@ -3,12 +3,7 @@ use freya::prelude::*;
 use crate::{
   app_state::AppState,
   payloads::MessageNotification,
-  util::{
-    bridge::BridgeMessage,
-    colors,
-    image::{circular_with_border, fetch_icon, image_from_bytes},
-    text::strip,
-  },
+  util::{bridge::BridgeMessage, colors, image::avatar_image, text::strip},
 };
 
 #[derive(PartialEq)]
@@ -50,7 +45,7 @@ impl Component for MessageRow {
           .width(Size::fill())
           .height(Size::fill())
           .child(
-            image_from_bytes(icon(&self.message.icon))
+            avatar_image(&self.message.icon, None)
               .width(Size::px(54.))
               .height(Size::px(54.))
               .margin(Gaps::new(0., 0., 0., 10.)),
@@ -84,8 +79,4 @@ impl Component for MessageRow {
           ),
       )
   }
-}
-
-fn icon(url: &str) -> Vec<u8> {
-  circular_with_border(fetch_icon(url, true).unwrap_or_default(), None).unwrap_or_default()
 }

--- a/src/components/messages_section.rs
+++ b/src/components/messages_section.rs
@@ -1,0 +1,53 @@
+use freya::prelude::*;
+
+use crate::{
+  app_state::AppState, components::MessageRow, config::CornerAlignment,
+  payloads::MessageNotification,
+};
+
+#[derive(PartialEq)]
+pub struct MessagesSection {
+  pub messages: Vec<MessageNotification>,
+  pub is_open: bool,
+  pub is_censor: bool,
+  pub message_alignment: String,
+  pub message_offset_x: i32,
+  pub message_offset_y: i32,
+  pub messages_semitransparent: bool,
+  pub app_state: State<AppState>,
+}
+
+impl Component for MessagesSection {
+  fn render(&self) -> impl IntoElement {
+    let alignment = CornerAlignment::from_str(&self.message_alignment);
+    let gaps = alignment.to_gaps(self.message_offset_x, self.message_offset_y);
+    let opacity = if self.messages_semitransparent && !self.is_open {
+      0.5
+    } else {
+      1.0
+    };
+
+    self.messages.iter().fold(
+      rect()
+        .direction(Direction::Vertical)
+        .cross_align(alignment.x.to_freya())
+        .main_align(alignment.y.to_freya())
+        .position(Position::new_absolute().top(0.).left(0.))
+        .background(Color::TRANSPARENT)
+        .height(Size::fill())
+        .width(Size::fill())
+        .padding(gaps)
+        .opacity(opacity),
+      |el, message| {
+        if self.is_censor {
+          el
+        } else {
+          el.child(MessageRow {
+            app_state: self.app_state,
+            message: message.clone(),
+          })
+        }
+      },
+    )
+  }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,7 +1,11 @@
 mod message_row;
+mod messages_section;
 mod user_row;
 mod voice_controls;
+mod voice_section;
 
 pub use message_row::MessageRow;
+pub use messages_section::MessagesSection;
 pub use user_row::UserRow;
 pub use voice_controls::VoiceControls;
+pub use voice_section::VoiceSection;

--- a/src/components/user_row.rs
+++ b/src/components/user_row.rs
@@ -3,10 +3,7 @@ use freya::prelude::*;
 
 use crate::{
   user::{User, UserVoiceState},
-  util::{
-    colors,
-    image::{circular_with_border, fetch_icon, image_from_bytes},
-  },
+  util::{colors, image::avatar_image},
 };
 
 static DEAFENED_SVG: &[u8] = include_bytes!("../../assets/deafened.svg");
@@ -20,12 +17,13 @@ struct AvatarIcon {
 
 impl Component for AvatarIcon {
   fn render(&self) -> impl IntoElement {
+    let (url, border) = avatar_url_and_border(&self.user);
     rect()
       .width(Size::px(50.))
       .height(Size::px(50.))
       .corner_radius(CornerRadius::new_all(25.))
       .child(
-        image_from_bytes(avatar(&self.user))
+        avatar_image(&url, border)
           .width(Size::fill())
           .height(Size::fill()),
       )
@@ -105,48 +103,44 @@ impl Component for UserRow {
       1.0
     };
 
-    rect()
+    let label = UserLabel {
+      user: self.user.clone(),
+    };
+    let icon = AvatarIcon {
+      user: self.user.clone(),
+    };
+
+    let row = rect()
       .direction(Direction::Horizontal)
       .main_align(Alignment::Start)
       .cross_align(Alignment::Center)
       .height(Size::px(50.))
       .margin(Gaps::new_all(6.))
-      .opacity(opacity)
-      .maybe(is_right_aligned, |el| {
-        el.child(UserLabel {
-          user: self.user.clone(),
-        })
-        .child(AvatarIcon {
-          user: self.user.clone(),
-        })
-      })
-      .maybe(!is_right_aligned, |el| {
-        el.child(AvatarIcon {
-          user: self.user.clone(),
-        })
-        .child(UserLabel {
-          user: self.user.clone(),
-        })
-      })
+      .opacity(opacity);
+
+    if is_right_aligned {
+      row.child(label).child(icon)
+    } else {
+      row.child(icon).child(label)
+    }
   }
 }
 
-fn avatar(user: &User) -> Vec<u8> {
+fn avatar_url_and_border(user: &User) -> (String, Option<SkColor>) {
   let border_color = match user.voice_state {
     UserVoiceState::Speaking => Some(SkColor::from_rgb(67, 147, 120)),
     UserVoiceState::Deafened | UserVoiceState::Muted => Some(SkColor::from_rgb(218, 62, 68)),
     _ => None,
   };
 
-  if user.avatar.is_empty() {
-    return circular_with_border(fetch_icon("", true).unwrap_or_default(), border_color)
-      .unwrap_or_default();
-  }
+  let url = if user.avatar.is_empty() {
+    String::new()
+  } else {
+    format!(
+      "https://cdn.discordapp.com/avatars/{}/{}.png?size=80",
+      user.id, user.avatar
+    )
+  };
 
-  let url = format!(
-    "https://cdn.discordapp.com/avatars/{}/{}.png?size=80",
-    user.id, user.avatar
-  );
-
-  circular_with_border(fetch_icon(&url, true).unwrap_or_default(), border_color).unwrap_or_default()
+  (url, border_color)
 }

--- a/src/components/voice_section.rs
+++ b/src/components/voice_section.rs
@@ -1,0 +1,51 @@
+use freya::prelude::*;
+
+use crate::{
+  components::UserRow,
+  config::{AxisAlignment, CornerAlignment},
+  user::User,
+  util::text::censor,
+};
+
+#[derive(PartialEq)]
+pub struct VoiceSection {
+  pub voice_users: Vec<User>,
+  pub is_open: bool,
+  pub is_censor: bool,
+  pub user_alignment: String,
+  pub user_offset_x: i32,
+  pub user_offset_y: i32,
+  pub voice_semitransparent: bool,
+}
+
+impl Component for VoiceSection {
+  fn render(&self) -> impl IntoElement {
+    let alignment = CornerAlignment::from_str(&self.user_alignment);
+    let gaps = alignment.to_gaps(self.user_offset_x, self.user_offset_y);
+    let is_right_aligned = alignment.x == AxisAlignment::End;
+
+    self.voice_users.iter().fold(
+      rect()
+        .direction(Direction::Vertical)
+        .cross_align(alignment.x.to_freya())
+        .main_align(alignment.y.to_freya())
+        .position(Position::new_absolute().top(0.).left(0.))
+        .background(Color::TRANSPARENT)
+        .height(Size::fill())
+        .width(Size::fill())
+        .padding(gaps),
+      |el, user| {
+        let mut u = user.clone();
+        if self.is_censor {
+          u.name = censor(&u.name);
+        }
+        el.child(UserRow {
+          user: u,
+          is_open: self.is_open,
+          is_right_aligned,
+          is_voice_semitransparent: self.voice_semitransparent,
+        })
+      },
+    )
+  }
+}

--- a/src/config_watcher.rs
+++ b/src/config_watcher.rs
@@ -17,7 +17,7 @@ pub fn start_config_watcher(shared: SharedAppState, redraw_tx: flume::Sender<()>
       Ok(w) => w,
       Err(e) => {
         warn!(
-          "Failed to create config watcher: {}. Live config reload disabled.",
+          "Failed to create config watcher: {}. Config changes will not reflect until Orbolay is restarted.",
           e
         );
         return;
@@ -27,14 +27,16 @@ pub fn start_config_watcher(shared: SharedAppState, redraw_tx: flume::Sender<()>
     let config_path = match config_dir() {
       Some(path) => path.join("config.json"),
       None => {
-        warn!("Failed to get config path; live config reload disabled");
+        warn!(
+          "Failed to get config path, config changes will not reflect until Orbolay is restarted"
+        );
         return;
       }
     };
 
     if let Err(e) = watcher.watch(&config_path, notify::RecursiveMode::NonRecursive) {
       warn!(
-        "Failed to watch config file at {:?}: {}. Live config reload disabled.",
+        "Failed to watch config file at {:?}: {}. Config changes will not reflect until Orbolay is restarted.",
         config_path, e
       );
       return;

--- a/src/config_watcher.rs
+++ b/src/config_watcher.rs
@@ -5,7 +5,7 @@ use notify::{Event, Result, Watcher};
 use crate::{
   app_state::SharedAppState,
   config::{config_dir, load_config},
-  log,
+  error, log, warn,
 };
 
 pub fn start_config_watcher(shared: SharedAppState, redraw_tx: flume::Sender<()>) {
@@ -13,19 +13,32 @@ pub fn start_config_watcher(shared: SharedAppState, redraw_tx: flume::Sender<()>
   std::thread::spawn(move || {
     let (tx, rx) = mpsc::channel::<Result<Event>>();
 
-    let mut watcher = notify::recommended_watcher(tx).expect("Failed to create config watcher");
-
-    let config_path = match config_dir() {
-      Some(path) => path.join("config.json"),
-      None => {
-        eprintln!("Failed to get config path");
+    let mut watcher = match notify::recommended_watcher(tx) {
+      Ok(w) => w,
+      Err(e) => {
+        warn!(
+          "Failed to create config watcher: {}. Live config reload disabled.",
+          e
+        );
         return;
       }
     };
 
-    watcher
-      .watch(&config_path, notify::RecursiveMode::NonRecursive)
-      .expect("Failed to watch config file");
+    let config_path = match config_dir() {
+      Some(path) => path.join("config.json"),
+      None => {
+        warn!("Failed to get config path; live config reload disabled");
+        return;
+      }
+    };
+
+    if let Err(e) = watcher.watch(&config_path, notify::RecursiveMode::NonRecursive) {
+      warn!(
+        "Failed to watch config file at {:?}: {}. Live config reload disabled.",
+        config_path, e
+      );
+      return;
+    }
 
     loop {
       match rx.recv() {
@@ -35,19 +48,19 @@ pub fn start_config_watcher(shared: SharedAppState, redraw_tx: flume::Sender<()>
           }
 
           if event.paths.iter().any(|p| p == &config_path) {
-            println!("Config file changed, reloading...");
+            log!("Config file changed, reloading...");
             if let Some(new_config) = load_config() {
               let mut state = shared.write().unwrap();
               state.config = new_config;
               redraw_tx.send(()).ok();
               log!("Config reloaded successfully");
             } else {
-              eprintln!("Failed to reload config file");
+              warn!("Failed to reload config file");
             }
           }
         }
-        Ok(Err(e)) => eprintln!("Watcher error: {}", e),
-        Err(e) => eprintln!("Watcher channel error: {}", e),
+        Ok(Err(e)) => error!("Watcher error: {}", e),
+        Err(e) => error!("Watcher channel error: {}", e),
       }
     }
   });

--- a/src/configurator/mod.rs
+++ b/src/configurator/mod.rs
@@ -3,7 +3,7 @@ use freya::prelude::*;
 
 use crate::{
   app_state::SharedAppState,
-  config::{Config, TransportMode, save_config},
+  config::{Config, TransportMode, load_config, save_config},
   util::colors::{GRAY, MUTED_GRAY, TRANSPARENT},
 };
 
@@ -46,6 +46,9 @@ pub fn open_configurator(shared: SharedAppState, redraw_tx: flume::Sender<()>) {
 pub fn open_configurator_standalone() {
   // Basically a blocking, standalone version of open_configurator
   let shared = SharedAppState::default();
+  if let Some(saved) = load_config() {
+    shared.write().unwrap().config = saved;
+  }
   let (redraw_tx, _) = flume::unbounded();
 
   launch(LaunchConfig::new().with_window(configurator_window(shared.clone(), redraw_tx)));

--- a/src/ipc/ipc_message_handler.rs
+++ b/src/ipc/ipc_message_handler.rs
@@ -139,7 +139,7 @@ pub fn handle_ipc_message(
         message_id: message.and_then(|m| m.id.clone()),
         title: data.title.clone(),
         body: data.body.clone(),
-        timestamp: Some(chrono::Utc::now().timestamp().to_string()),
+        timestamp: Some(chrono::Utc::now().timestamp()),
         icon: data
           .icon_url
           .clone()

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -35,16 +35,18 @@ pub fn watch_keybinds(shared: SharedAppState, keybind_tx: flume::Sender<KeyEvent
     let shared = shared.clone();
     thread::spawn(move || {
       loop {
-        let config = shared.read().unwrap().config.clone();
+        let (is_enabled, overlay_keybind) = {
+          let state = shared.read().unwrap();
+          (
+            state.config.is_keybind_enabled.unwrap_or(true),
+            state.config.overlay_keybind.clone(),
+          )
+        };
 
-        enabled.store(config.is_keybind_enabled.unwrap_or(true), Ordering::Relaxed);
+        enabled.store(is_enabled, Ordering::Relaxed);
 
-        let overlay_keys = strings_to_keys(
-          config
-            .overlay_keybind
-            .clone()
-            .unwrap_or_else(|| DEFAULT_OVERLAY_TOGGLE.clone()),
-        );
+        let overlay_keys =
+          strings_to_keys(overlay_keybind.unwrap_or_else(|| DEFAULT_OVERLAY_TOGGLE.clone()));
 
         {
           let mut kbs = keybinds.write().unwrap();

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use std::io::Write;
 
 use chrono::Local;
 use colored::Colorize;
@@ -19,7 +20,8 @@ pub fn log(s: impl AsRef<str> + Display, kind: Option<LogKind>) {
     None => "INFO".blue(),
   };
 
-  println!(
+  let _ = writeln!(
+    std::io::stdout().lock(),
     "[{}] [{}] {}",
     Local::now().format("%Y-%m-%d %H:%M:%S"),
     status,

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,7 +214,7 @@ fn app() -> impl IntoElement {
         GIT_HASH.unwrap_or("unknown")
       ),
       body: "by SpikeHD".to_string(),
-      timestamp: Some(chrono::Utc::now().timestamp().to_string()),
+      timestamp: Some(chrono::Utc::now().timestamp()),
       icon: "https://avatars.githubusercontent.com/u/25207995?v=4".to_string(),
       guild_id: None,
       channel_id: None,
@@ -258,14 +258,14 @@ fn app() -> impl IntoElement {
       while let Ok(event) = keybind_rx.recv_async().await {
         match event {
           keys::KeyEvent::ToggleOverlay => {
-            let current = app_state.read().is_open;
-            app_state.write().is_open = !current;
+            let mut state = app_state.write();
+            state.is_open = !state.is_open;
           }
           keys::KeyEvent::OpenConfigurator if app_state.read().is_open => {
             open_configurator(shared.clone(), redraw_tx.clone());
             app_state.write().is_open = false;
           }
-          _ => {}
+          keys::KeyEvent::OpenConfigurator => {}
         }
       }
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ use winit::{
 
 use crate::{
   app_state::{AppState, SharedAppState},
-  components::{MessageRow, UserRow, VoiceControls},
-  config::{CornerAlignment, is_first_run, load_config, save_config},
+  components::{MessagesSection, VoiceControls, VoiceSection},
+  config::{is_first_run, load_config, save_config},
   config_watcher::start_config_watcher,
   configurator::{open_configurator, open_configurator_standalone},
   display::{specific_monitor_or_primary, update_monitor},
@@ -27,7 +27,7 @@ use crate::{
   payloads::MessageNotification,
   transport::create_transport_thread,
   updates::maybe_notify_update,
-  util::{colors, text::censor},
+  util::colors,
 };
 
 mod app_state;
@@ -282,77 +282,15 @@ fn app() -> impl IntoElement {
   let state = app_state.read();
   let voice_users = state.voice_users.clone();
   let messages = state.messages.clone();
+  let is_open = state.is_open;
+  let is_censor = state.is_censor;
+  let config = state.config.clone();
   let current_user = state
     .voice_users
     .iter()
     .find(|u| u.id == state.config.user_id)
     .cloned();
-
-  let user_alignment =
-    CornerAlignment::from_str(state.config.user_alignment.as_deref().unwrap_or("topleft"));
-  let msg_alignment = CornerAlignment::from_str(
-    state
-      .config
-      .message_alignment
-      .as_deref()
-      .unwrap_or("topright"),
-  );
-
-  let user_gaps = user_alignment.to_gaps(state.config.user_offset_x, state.config.user_offset_y);
-  let msg_gaps =
-    msg_alignment.to_gaps(state.config.message_offset_x, state.config.message_offset_y);
-
-  // Root container
-  let voice_section = voice_users.iter().fold(
-    rect()
-      .direction(Direction::Vertical)
-      .cross_align(user_alignment.x.to_freya())
-      .main_align(user_alignment.y.to_freya())
-      .position(Position::new_absolute().top(0.).left(0.))
-      .background(Color::TRANSPARENT)
-      .height(Size::fill())
-      .width(Size::fill())
-      .padding(user_gaps),
-    |el, user| {
-      let mut u = user.clone();
-      if state.is_censor {
-        u.name = censor(&u.name);
-      }
-      el.child(UserRow {
-        user: u,
-        is_open: state.is_open,
-        is_right_aligned: user_alignment.x == config::AxisAlignment::End,
-        is_voice_semitransparent: state.config.voice_semitransparent.unwrap_or(true),
-      })
-    },
-  );
-
-  let messages_section = messages.iter().fold(
-    rect()
-      .direction(Direction::Vertical)
-      .cross_align(msg_alignment.x.to_freya())
-      .main_align(msg_alignment.y.to_freya())
-      .position(Position::new_absolute().top(0.).left(0.))
-      .background(Color::TRANSPARENT)
-      .height(Size::fill())
-      .width(Size::fill())
-      .padding(msg_gaps)
-      .opacity(if state.config.messages_semitransparent && !state.is_open {
-        0.5
-      } else {
-        1.0
-      }),
-    |el, message| {
-      if state.is_censor {
-        el
-      } else {
-        el.child(MessageRow {
-          app_state,
-          message: message.clone(),
-        })
-      }
-    },
-  );
+  drop(state);
 
   rect()
     .width(Size::fill())
@@ -361,7 +299,7 @@ fn app() -> impl IntoElement {
     .child(
       rect()
         .position(Position::new_absolute().top(0.).left(0.))
-        .background(if state.is_open {
+        .background(if is_open {
           colors::TRANSPARENT_GRAY
         } else {
           Color::TRANSPARENT
@@ -373,11 +311,34 @@ fn app() -> impl IntoElement {
         }),
     )
     // Voice users
-    .child(voice_section)
+    .child(VoiceSection {
+      voice_users,
+      is_open,
+      is_censor,
+      user_alignment: config
+        .user_alignment
+        .clone()
+        .unwrap_or_else(|| "topleft".into()),
+      user_offset_x: config.user_offset_x,
+      user_offset_y: config.user_offset_y,
+      voice_semitransparent: config.voice_semitransparent.unwrap_or(true),
+    })
     // Messages
-    .child(messages_section)
+    .child(MessagesSection {
+      messages,
+      is_open,
+      is_censor,
+      message_alignment: config
+        .message_alignment
+        .clone()
+        .unwrap_or_else(|| "topright".into()),
+      message_offset_x: config.message_offset_x,
+      message_offset_y: config.message_offset_y,
+      messages_semitransparent: config.messages_semitransparent,
+      app_state,
+    })
     // Voice controls
-    .maybe(state.is_open, |el| {
+    .maybe(is_open, |el| {
       el.maybe_child(current_user.map(|user| {
         rect()
           .position(Position::new_absolute().top(0.).left(0.))

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -11,8 +11,8 @@ pub fn create_notification_thread(shared: SharedAppState, redraw_tx: flume::Send
         let before = state.messages.len();
 
         state.messages.retain(|message| {
-          if let Some(ts) = &message.timestamp {
-            return current_timestamp - ts.parse::<i64>().unwrap_or(0) < 5;
+          if let Some(ts) = message.timestamp {
+            return current_timestamp - ts < 5;
           }
           true
         });

--- a/src/payloads.rs
+++ b/src/payloads.rs
@@ -64,7 +64,8 @@ pub struct MessageNotification {
   pub guild_id: Option<String>,
   pub channel_id: Option<String>,
   pub message_id: Option<String>,
-  pub timestamp: Option<String>,
+  #[serde(default, skip_deserializing)]
+  pub timestamp: Option<i64>,
 }
 
 impl Default for MessageNotification {
@@ -76,7 +77,7 @@ impl Default for MessageNotification {
       guild_id: None,
       channel_id: None,
       message_id: None,
-      timestamp: Some(chrono::Utc::now().timestamp().to_string()),
+      timestamp: Some(chrono::Utc::now().timestamp()),
     }
   }
 }

--- a/src/updates/mod.rs
+++ b/src/updates/mod.rs
@@ -1,17 +1,23 @@
 use serde_json::Value;
 
-use crate::{app_state::SharedAppState, payloads::MessageNotification};
+use crate::{app_state::SharedAppState, payloads::MessageNotification, warn};
 
 pub fn maybe_notify_update(shared: SharedAppState) {
   std::thread::spawn(move || {
-    let mut resp = ureq::get("https://api.github.com/repos/SpikeHD/orbolay/releases/latest")
-      .call()
-      .expect("Failed to get latest Orbolay release");
-    let json = resp
-      .body_mut()
-      .read_to_string()
-      .expect("Failed to read response body");
-    let json = serde_json::from_str::<Value>(&json).expect("Failed to parse response body as JSON");
+    let Ok(mut resp) =
+      ureq::get("https://api.github.com/repos/SpikeHD/orbolay/releases/latest").call()
+    else {
+      warn!("Failed to check for updates: request failed");
+      return;
+    };
+    let Ok(body) = resp.body_mut().read_to_string() else {
+      warn!("Failed to check for updates: could not read response body");
+      return;
+    };
+    let Ok(json) = serde_json::from_str::<Value>(&body) else {
+      warn!("Failed to check for updates: could not parse response as JSON");
+      return;
+    };
 
     if let Some(latest_version) = json.get("tag_name").and_then(|v| v.as_str()) {
       let current_version = format!("v{}", env!("CARGO_PKG_VERSION"));

--- a/src/util/image.rs
+++ b/src/util/image.rs
@@ -17,22 +17,68 @@ use crate::log;
 static AVATAR_CACHE: LazyLock<Mutex<HashMap<String, Vec<u8>>>> =
   LazyLock::new(|| Mutex::new(HashMap::new()));
 
+struct CachedAvatar {
+  image: SkImage,
+  bytes: Bytes,
+}
+
+type AvatarImageCache = Mutex<HashMap<(String, Option<u32>), CachedAvatar>>;
+
+static AVATAR_IMAGE_CACHE: LazyLock<AvatarImageCache> =
+  LazyLock::new(|| Mutex::new(HashMap::new()));
+
 pub static DEFAULT_AVATAR: &[u8] = include_bytes!("../../assets/discordgrey.png");
 
 const OUTPUT_RES: (i32, i32) = (256, 256);
 
-pub fn image_from_bytes(bytes: Vec<u8>) -> FreyaImage {
-  let data = if bytes.is_empty() {
-    DEFAULT_AVATAR
-  } else {
-    &bytes
+fn border_key(border: Option<SkColor>) -> Option<u32> {
+  border.map(|c| {
+    ((c.a() as u32) << 24) | ((c.r() as u32) << 16) | ((c.g() as u32) << 8) | (c.b() as u32)
+  })
+}
+
+pub fn avatar_image(url: &str, border: Option<SkColor>) -> FreyaImage {
+  let key = (url.to_string(), border_key(border));
+
+  let hit = {
+    let cache = AVATAR_IMAGE_CACHE.lock().unwrap();
+    cache.get(&key).map(|c| (c.image.clone(), c.bytes.clone()))
   };
-  let sk_image = SkImage::from_encoded(SkData::new_copy(data))
-    .or_else(|| SkImage::from_encoded(SkData::new_copy(DEFAULT_AVATAR)))
-    .expect("Failed to decode avatar and fallback image");
+  if let Some((image, bytes)) = hit {
+    return img_fn(ImageHolder {
+      image: Rc::new(RefCell::new(image)),
+      bytes,
+    });
+  }
+
+  let raw = fetch_icon(url, true).unwrap_or_default();
+  let processed = circular_with_border(raw, border).unwrap_or_default();
+
+  if processed.is_empty() {
+    let bytes = Bytes::from_static(DEFAULT_AVATAR);
+    let sk_image =
+      SkImage::from_encoded(SkData::new_copy(&bytes)).expect("Failed to decode default avatar");
+    return img_fn(ImageHolder {
+      image: Rc::new(RefCell::new(sk_image)),
+      bytes,
+    });
+  }
+
+  let bytes = Bytes::from(processed);
+  let sk_image =
+    SkImage::from_encoded(SkData::new_copy(&bytes)).expect("Failed to decode processed avatar");
+
+  AVATAR_IMAGE_CACHE.lock().unwrap().insert(
+    key,
+    CachedAvatar {
+      image: sk_image.clone(),
+      bytes: bytes.clone(),
+    },
+  );
+
   img_fn(ImageHolder {
     image: Rc::new(RefCell::new(sk_image)),
-    bytes: Bytes::from(bytes),
+    bytes,
   })
 }
 

--- a/src/util/image.rs
+++ b/src/util/image.rs
@@ -44,6 +44,7 @@ pub fn avatar_image(url: &str, border: Option<SkColor>) -> FreyaImage {
     let cache = AVATAR_IMAGE_CACHE.lock().unwrap();
     cache.get(&key).map(|c| (c.image.clone(), c.bytes.clone()))
   };
+
   if let Some((image, bytes)) = hit {
     return img_fn(ImageHolder {
       image: Rc::new(RefCell::new(image)),

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -63,39 +63,39 @@ fn ws_stream(
 
   log!("Stream connected");
 
-  loop {
-    std::thread::sleep(std::time::Duration::from_millis(50));
-
-    if let Ok(msg) = websocket.read() {
-      if msg.is_close() {
-        log!("Stream closed");
-        shared.write().unwrap().voice_users = vec![];
-        let _ = redraw_tx.send(());
-        break;
-      }
-
-      if msg.is_empty() {
-        continue;
-      }
-
-      let msg = msg.to_string();
-      let msg: BridgeMessage = serde_json::from_str(&msg)?;
-
-      if let Err(e) = handle_ws_message(&msg, shared.clone(), &redraw_tx) {
-        error!("Failed to handle websocket message: {}", e);
-      }
-    } else {
-      if let Ok(msg) = ws_receiver.try_recv() {
-        let msg = serde_json::to_string(&msg)?;
-        log!("Sending message to websocket: {:?}", msg);
-        websocket
-          .write(Message::Text(Utf8Bytes::from(msg)))
-          .unwrap_or_else(|_| error!("Failed to send message to websocket, socket closed?"));
-        websocket
-          .flush()
-          .unwrap_or_else(|_| error!("Failed to flush message to websocket, socket closed?"));
+  'outer: loop {
+    loop {
+      match websocket.read() {
+        Ok(msg) if msg.is_close() => {
+          log!("Stream closed");
+          shared.write().unwrap().voice_users = vec![];
+          let _ = redraw_tx.send(());
+          break 'outer;
+        }
+        Ok(msg) if msg.is_empty() => continue,
+        Ok(msg) => {
+          let msg = msg.to_string();
+          let msg: BridgeMessage = serde_json::from_str(&msg)?;
+          if let Err(e) = handle_ws_message(&msg, shared.clone(), &redraw_tx) {
+            error!("Failed to handle websocket message: {}", e);
+          }
+        }
+        Err(_) => break,
       }
     }
+
+    if let Ok(msg) = ws_receiver.try_recv() {
+      let msg = serde_json::to_string(&msg)?;
+      log!("Sending message to websocket: {:?}", msg);
+      websocket
+        .write(Message::Text(Utf8Bytes::from(msg)))
+        .unwrap_or_else(|_| error!("Failed to send message to websocket, socket closed?"));
+      websocket
+        .flush()
+        .unwrap_or_else(|_| error!("Failed to flush message to websocket, socket closed?"));
+    }
+
+    std::thread::sleep(std::time::Duration::from_millis(10));
   }
   Ok(())
 }
@@ -118,28 +118,28 @@ pub fn handle_ws_message(
         .and_then(|v| v.as_str())
         .unwrap_or_default()
         .to_string();
-      let existing = shared.read().unwrap().config.clone();
+      let mut state = shared.write().unwrap();
+      let existing = state.config.clone();
       let mut data = serde_json::from_value::<Config>(data).unwrap_or(existing);
       data.user_id = user_id;
-      shared.write().unwrap().config = data;
+      state.config = data;
     }
     "CHANNEL_JOINED" => {
       let data = serde_json::from_value::<ChannelJoinPayload>(data)?;
-      let mut users = vec![];
+      let mut state = shared.write().unwrap();
+      let user_id = state.config.user_id.clone();
+      let mut users = Vec::with_capacity(data.states.len());
 
-      let user_id = shared.read().unwrap().config.user_id.clone();
       for voice_state in data.states {
         if voice_state.user_id == user_id {
-          shared.write().unwrap().current_channel =
-            voice_state.channel_id.clone().unwrap_or("0".to_string());
+          state.current_channel = voice_state.channel_id.clone().unwrap_or("0".to_string());
         }
         users.push(voice_state.into());
       }
 
-      shared.write().unwrap().voice_users = users;
+      state.voice_users = users;
     }
     "VOICE_STATE_UPDATE" => {
-      let current_channel = shared.read().unwrap().current_channel.clone();
       let channel_is_null = msg
         .data
         .get("state")
@@ -148,12 +148,12 @@ pub fn handle_ws_message(
         .unwrap_or(false);
       let mut data = serde_json::from_value::<UpdatePayload>(msg.data.clone())?;
 
+      let mut state = shared.write().unwrap();
+
       let should_remove = match &data.state.channel_id {
-        Some(channel_id) => channel_id != &current_channel,
+        Some(channel_id) => channel_id != &state.current_channel,
         None => channel_is_null,
       };
-
-      let mut state = shared.write().unwrap();
 
       if should_remove {
         state
@@ -183,7 +183,7 @@ pub fn handle_ws_message(
     }
     "MESSAGE_NOTIFICATION" => {
       let mut data = serde_json::from_value::<MessageNotificationPayload>(data)?;
-      data.message.timestamp = Some(chrono::Utc::now().timestamp().to_string());
+      data.message.timestamp = Some(chrono::Utc::now().timestamp());
       data.message.icon = data.message.icon.replace(".webp", ".png");
       shared.write().unwrap().notify(data.message);
     }


### PR DESCRIPTION
- cache decoded avatars (image + processed bytes) per (url, border); failed fetches skip caching
- split app() into memoized voicesection and messagessection so unrelated state changes dont rerender both
- userrow clones the user once instead of up to four times
- drain queued ws messages before sleeping; fixes ~5s leave lag in busy channels
- single write() per ws handler arm instead of 3-5 lock roundtrips
- keybind poll reads only the two feilds it needs instead of cloning full config
- messagenotification.timestamp is option<i64>; wire field is skip_deserializing
- toggleoverlay closure uses one write() instead of read() then write()